### PR TITLE
Stabilizing state change

### DIFF
--- a/src/TbDetailsList.tsx
+++ b/src/TbDetailsList.tsx
@@ -60,7 +60,12 @@ export const TbDetailsList: React.FunctionComponent<ITbDetailsListProps> = ({
 
     const handleMissingItems = (index?: number, rowProps?: IDetailsRowProps): React.ReactNode => {
         const newRowProps: IDetailsRowProps = { ...rowProps };
-        tbFabricInstance.api.loadMoreItems(index);
+
+        // We need to delay loadMoreItems since
+        // we are at the render phase here.
+        setTimeout(() => {
+            tbFabricInstance.api.loadMoreItems(index);
+        });
 
         return <DetailsRow {...newRowProps} item={DEFAULT_MISSING_ITEM} styles={shimmerWrapper} />;
     };

--- a/src/useTbFabric.ts
+++ b/src/useTbFabric.ts
@@ -73,33 +73,37 @@ export const useTbFabric = (
     };
 
     const sortByColumn = (ev?: React.MouseEvent<HTMLElement>, column?: IColumn) => {
-        resetList();
-        const newFabricColumns = fabricColumns.map((col) => {
-            if (col.fieldName === column.fieldName) {
-                const isSortedDescending = col.isSorted && !col.isSortedDescending;
-                const isSorted = col.isSorted ? (col.isSortedDescending ? false : true) : true;
+        unstable_batchedUpdates(() => {
+            resetList();
+            const newFabricColumns = fabricColumns.map((col) => {
+                if (col.fieldName === column.fieldName) {
+                    const isSortedDescending = col.isSorted && !col.isSortedDescending;
+                    const isSorted = col.isSorted ? (col.isSortedDescending ? false : true) : true;
+
+                    return {
+                        ...col,
+                        isSorted: isSorted,
+                        isSortedDescending: isSortedDescending,
+                    };
+                }
 
                 return {
                     ...col,
-                    isSorted: isSorted,
-                    isSortedDescending: isSortedDescending,
+                    isSorted: false,
+                    isSortedDescending: false,
                 };
-            }
+            });
 
-            return {
-                ...col,
-                isSorted: false,
-                isSortedDescending: false,
-            };
+            setFabricColumns(newFabricColumns);
+            tubular.api.sortColumn(column.fieldName);
         });
-
-        setFabricColumns(newFabricColumns);
-        tubular.api.sortColumn(column.fieldName);
     };
 
     const search = (value: string) => {
-        resetList();
-        tubular.api.updateSearchText(value);
+        unstable_batchedUpdates(() => {
+            resetList();
+            tubular.api.updateSearchText(value);
+        });
     };
 
     const updateVisibleColumns = (columns: ColumnModel[]): [ITbColumn[], ColumnModel[]] => {


### PR DESCRIPTION
There was an issue when requesting to load more items on the detailslist. Since we are at the render phase by that time, we needed to delay the request a little bit.

I have wrapped some api methods in order to batch all state changes and avoid re-renders.