### PR TITLE
Blocking sort when request in progress and adding filter visual feedback

### DIFF
--- a/src/TbDetailsList.tsx
+++ b/src/TbDetailsList.tsx
@@ -97,6 +97,15 @@ export const TbDetailsList: React.FunctionComponent<ITbDetailsListProps> = ({
         return onRenderItemColumn ? onRenderItemColumn(item, index, column) : getRenderByDataType(item, column);
     };
 
+    const onColumnHeaderClick = React.useCallback(
+        () => (ev?: React.MouseEvent<HTMLElement>, column?: IColumn) => {
+            if (!tbState.isLoading) {
+                tbApi.sortByColumn(ev, column);
+            }
+        },
+        [tbState.isLoading],
+    );
+
     return (
         <div className={classes.tbDetailsList} data-is-scrollable="true">
             {selectionMode && selectionMode !== SelectionMode.none && selectedRowsCount > 0 && (
@@ -110,7 +119,7 @@ export const TbDetailsList: React.FunctionComponent<ITbDetailsListProps> = ({
                 columns={tbState.fabricColumns}
                 onRenderMissingItem={handleMissingItems}
                 selectionPreservedOnEmptyClick={true}
-                onColumnHeaderClick={tbApi.sortByColumn}
+                onColumnHeaderClick={onColumnHeaderClick()}
                 selectionMode={selectionMode || SelectionMode.none}
             />
         </div>


### PR DESCRIPTION
Two main changes here:
- Sort functionality is blocked whenever there's a pending request
- Visual feedback has been added for columns with filters (See screenshot)

![image](https://user-images.githubusercontent.com/399019/94858084-1c823480-03f8-11eb-91d7-1be8cc5f9dcb.png)
