### PR TITLE
fix(DateFilter): prevent Invalid Date and crash when switching to Between

### DIFF
--- a/src/filterControls/DateFilter.tsx
+++ b/src/filterControls/DateFilter.tsx
@@ -51,7 +51,7 @@ const dateInputClassName = mergeStyles({
     paddingRight: '8px',
 });
 
-const getInitialDates = (column: ColumnModel) => {
+export const getInitialDates = (column: ColumnModel) => {
     const dates = [null, null];
 
     const startDate = Date.parse(column.filterText);
@@ -64,7 +64,7 @@ const getInitialDates = (column: ColumnModel) => {
         column.filterArgument && column.filterArgument[0] ? column.filterArgument[0].toString() : null,
     );
 
-    if (!isNaN(startDate)) {
+    if (!isNaN(toDate)) {
         dates[1] = new Date(toDate);
     }
 

--- a/src/useTbFabric.ts
+++ b/src/useTbFabric.ts
@@ -15,6 +15,17 @@ import { ITbColumnProxy, TbSupportedIColumnProps } from './interfaces/ITbColumn'
 import { ITbFabricInstance } from './interfaces/ITbFabricInstance';
 import { ITbFabricApi } from './interfaces';
 
+// A "Between" filter needs both bounds. When the upper bound is missing (e.g. the user
+// switched to "Between" from a single-value operator but never picked the second value),
+// downgrade to ">=" so downstream consumers that dereference filterArgument[0] (local
+// transformer, chip rendering) don't crash on an incomplete filter.
+export const normalizeIncompleteBetween = (column: ColumnModel): void => {
+    if (column.filterOperator === CompareOperators.Between && (!column.filterArgument || !column.filterArgument[0])) {
+        column.filterOperator = CompareOperators.Gte;
+        column.filterArgument = null;
+    }
+};
+
 const createInitialTbColumns = (proxyColumns: ITbColumnProxy[]): ColumnModel[] =>
     proxyColumns.map((column) =>
         createColumn(column.name, {
@@ -140,13 +151,7 @@ const useTbFabric = (
                 column.filterOperator = fColumn.filterOperator;
                 column.filterArgument = fColumn.filterArgument;
 
-                if (
-                    column.filterOperator === CompareOperators.Between &&
-                    (!column.filterArgument || !column.filterArgument[0])
-                ) {
-                    column.filterOperator = CompareOperators.Gte;
-                    column.filterArgument = null;
-                }
+                normalizeIncompleteBetween(column);
             } else {
                 column.filterText = null;
                 column.filterOperator = CompareOperators.None;
@@ -180,6 +185,8 @@ const useTbFabric = (
     const applyFilter = (columnName: string, value: string) => applyOrResetFilter(columnName, value);
 
     const applyFeatures = (columns: ColumnModel[]) => {
+        columns.forEach(normalizeIncompleteBetween);
+
         unstable_batchedUpdates(() => {
             resetList();
             tbApi.setColumns(columns);

--- a/test/DateFilterBetween.spec.tsx
+++ b/test/DateFilterBetween.spec.tsx
@@ -1,0 +1,70 @@
+import { ColumnDataType, ColumnModel, CompareOperators, createColumn } from 'tubular-common';
+import { getInitialDates } from '../src/filterControls/DateFilter';
+
+const dateColumn = (overrides: Partial<ColumnModel>): ColumnModel =>
+    createColumn('Created', {
+        dataType: ColumnDataType.DateTime,
+        filterable: true,
+        ...overrides,
+    });
+
+const isInvalidDate = (value: unknown): boolean => value instanceof Date && isNaN(value.getTime());
+
+describe('DateFilter - getInitialDates', () => {
+    it('should not produce an Invalid Date for the upper bound when there is none yet', () => {
+        // Switching to "Between" right after a single-value operator (e.g. Equals):
+        // the lower bound (filterText) is set, but filterArgument is still empty.
+        const [from, to] = getInitialDates(
+            dateColumn({
+                filterOperator: CompareOperators.Between,
+                filterText: '2020-01-01',
+                filterArgument: [],
+            }),
+        );
+
+        expect(from).toBeInstanceOf(Date);
+        expect(isInvalidDate(from)).toBe(false);
+        expect(to).toBeNull();
+    });
+
+    it('should not produce an Invalid Date for the upper bound when filterArgument is undefined', () => {
+        const [, to] = getInitialDates(
+            dateColumn({
+                filterOperator: CompareOperators.Between,
+                filterText: '2020-01-01',
+                filterArgument: undefined,
+            }),
+        );
+
+        expect(to).toBeNull();
+        expect(isInvalidDate(to)).toBe(false);
+    });
+
+    it('should populate both bounds when a valid upper bound exists', () => {
+        const [from, to] = getInitialDates(
+            dateColumn({
+                filterOperator: CompareOperators.Between,
+                filterText: '2020-01-01',
+                filterArgument: ['2020-02-01'],
+            }),
+        );
+
+        expect(from).toBeInstanceOf(Date);
+        expect(to).toBeInstanceOf(Date);
+        expect(isInvalidDate(from)).toBe(false);
+        expect(isInvalidDate(to)).toBe(false);
+    });
+
+    it('should return nulls when there is no filter yet', () => {
+        const [from, to] = getInitialDates(
+            dateColumn({
+                filterOperator: CompareOperators.None,
+                filterText: undefined,
+                filterArgument: undefined,
+            }),
+        );
+
+        expect(from).toBeNull();
+        expect(to).toBeNull();
+    });
+});

--- a/test/useTbFabric.spec.ts
+++ b/test/useTbFabric.spec.ts
@@ -1,0 +1,76 @@
+import { ColumnDataType, ColumnModel, CompareOperators, createColumn } from 'tubular-common';
+import { normalizeIncompleteBetween } from '../src/useTbFabric';
+
+const dateColumn = (overrides: Partial<ColumnModel>): ColumnModel =>
+    createColumn('Created', {
+        dataType: ColumnDataType.DateTime,
+        filterable: true,
+        ...overrides,
+    });
+
+describe('normalizeIncompleteBetween', () => {
+    it('should downgrade an incomplete Between (undefined filterArgument) to Gte', () => {
+        const column = dateColumn({
+            filterOperator: CompareOperators.Between,
+            filterText: '01/01/2020',
+            filterArgument: undefined,
+        });
+
+        normalizeIncompleteBetween(column);
+
+        expect(column.filterOperator).toBe(CompareOperators.Gte);
+        expect(column.filterArgument).toBeNull();
+    });
+
+    it('should downgrade an incomplete Between (empty filterArgument) to Gte', () => {
+        const column = dateColumn({
+            filterOperator: CompareOperators.Between,
+            filterText: '01/01/2020',
+            filterArgument: [],
+        });
+
+        normalizeIncompleteBetween(column);
+
+        expect(column.filterOperator).toBe(CompareOperators.Gte);
+        expect(column.filterArgument).toBeNull();
+    });
+
+    it('should downgrade an incomplete Between (falsy upper bound) to Gte', () => {
+        const column = dateColumn({
+            filterOperator: CompareOperators.Between,
+            filterText: '01/01/2020',
+            filterArgument: [null],
+        });
+
+        normalizeIncompleteBetween(column);
+
+        expect(column.filterOperator).toBe(CompareOperators.Gte);
+        expect(column.filterArgument).toBeNull();
+    });
+
+    it('should leave a complete Between filter untouched', () => {
+        const column = dateColumn({
+            filterOperator: CompareOperators.Between,
+            filterText: '01/01/2020',
+            filterArgument: ['01/02/2020'],
+        });
+
+        normalizeIncompleteBetween(column);
+
+        expect(column.filterOperator).toBe(CompareOperators.Between);
+        expect(column.filterArgument).toEqual(['01/02/2020']);
+    });
+
+    it('should leave non-Between operators untouched', () => {
+        const column = dateColumn({
+            filterOperator: CompareOperators.Equals,
+            filterText: '01/01/2020',
+            filterArgument: undefined,
+        });
+
+        normalizeIncompleteBetween(column);
+
+        expect(column.filterOperator).toBe(CompareOperators.Equals);
+        expect(column.filterArgument).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a broken and crashing date-column filter when the "Between" operator is selected after a single-value operator.

**Repro:** apply a single-value date filter (Equals, `>=`, `>`, `<=`, `<`) on a date column, then reopen the filter and switch the operator to **Between**. The second ("To") input renders **`Invalid Date`**, and pressing **Apply** crashes the grid with `Cannot read properties of undefined (reading '0')`.

## Root cause

1. **`DateFilter.getInitialDates`** guarded the upper-bound date with the *lower* bound's validity (`!isNaN(startDate)` instead of `!isNaN(toDate)`). With a valid lower bound and no upper bound yet, `toDate` is `NaN` but the check passed, producing `new Date(NaN)` → `Invalid Date` in the "To" field.

2. **`useTbFabric.applyFeatures`** (the code path used by `FeaturesPanel`'s Apply) did **not** sanitize an incomplete "Between" filter, unlike `applyFilters` which already downgrades it. Applying "Between" with an undefined `filterArgument` left downstream consumers dereferencing `filterArgument[0]` on `undefined` — both the local data transformer (`tubular-common` `getResponse`) and the chip renderer (`ChipFilter.getFilterText`) — which threw.

## Changes

- **`DateFilter.getInitialDates`**: correct the guard to `!isNaN(toDate)` so the "To" bound stays empty until a valid upper bound exists.
- **`useTbFabric`**: extract the incomplete-"Between" guard into `normalizeIncompleteBetween` and apply it in `applyFeatures` as well as `applyFilters`, downgrading to `>=` (and clearing `filterArgument`) when the upper bound is missing.
- **Tests**: add unit coverage for `getInitialDates` (no `Invalid Date` for a missing upper bound; both bounds populated when valid) and for `normalizeIncompleteBetween` (downgrades undefined/empty/falsy upper bounds; leaves complete Between and non-Between operators untouched).

## Verification

- New specs pass (`test/DateFilterBetween.spec.tsx`, `test/useTbFabric.spec.ts`).
- Red evidence: reverting the `getInitialDates` guard makes the new spec fail with the upper bound coming back as `Date { NaN }`.
- `npm run build` (tsc) is clean; Prettier passes on the changed files.

## Notes

The new specs are intentionally self-contained (they build columns via `createColumn` instead of importing `test/mock`) because `test/mock/index.ts` currently fails to type-check under the pinned `@types/react`, which blocks compilation of every spec that imports it. That is a pre-existing issue on `master` (CI has been red on it) and is left out of scope here.
