### PR TITLE
ci: add manual branch-selectable npm publish workflow

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -1,0 +1,105 @@
+name: npm Publish (manual)
+
+# Manually publish tubular-fabric from ANY branch, on demand, from the Actions UI.
+#
+# Why this exists: the automatic "npm Publish" workflow only fires on push to
+# master and always bumps a minor on the master line. That is the wrong tool for
+# a maintenance/back-port release (e.g. shipping a fix on the 3.13.x line without
+# dragging in newer transitive dependencies from master).
+#
+# This workflow lives on the default branch (so it shows up in the "Run workflow"
+# UI) but publishes the CODE of whatever branch you pass in `branch`. The target
+# branch does NOT need to contain this file.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to publish from (its code is what gets published)"
+        required: true
+        type: string
+      bump:
+        description: "Version bump to apply before publishing"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - none
+      dist_tag:
+        description: "npm dist-tag to publish under. Keep 'latest' reserved for the master line; use e.g. v3-lts for back-ports."
+        required: true
+        default: v3-lts
+        type: string
+
+# Needed so the post-publish version bump can be committed back to the branch.
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: 🛎 Checkout selected branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GPR_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: 🟩 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "18.20.4"
+          registry-url: https://registry.npmjs.org/
+
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          # Pinned to 9 to match the repo's lockfileVersion 9.0 and stay
+          # compatible with Node 18 (pnpm 11 requires Node >= 22.13).
+          version: 9
+          run_install: false
+
+      - name: 🤡 pnpm install
+        # Not --frozen-lockfile: this workflow may target older maintenance
+        # branches whose lockfile predates the current pnpm. Any incidental
+        # lockfile change is not committed back (see the commit step's `add`).
+        run: pnpm install
+
+      - name: 🏗 Build
+        run: pnpm build
+
+      - name: 🐝 Bump version
+        if: ${{ inputs.bump != 'none' }}
+        run: npm version --no-git-tag-version ${{ inputs.bump }}
+
+      - name: 🔖 Resolve published version
+        id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: 🍱 Publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          pnpm publish --no-git-checks --tag "${{ inputs.dist_tag }}"
+
+      - name: 📌 Commit version bump
+        if: ${{ inputs.bump != 'none' }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "package.json"
+          message: "[skip ci] Bump version to ${{ steps.version.outputs.value }} (manual publish from ${{ inputs.branch }})"
+          default_author: github_actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GPR_ACCESS_TOKEN }}
+
+      - name: ✅ Summary
+        run: |
+          echo "Published **tubular-fabric@${{ steps.version.outputs.value }}** under dist-tag **${{ inputs.dist_tag }}** from branch **${{ inputs.branch }}**." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Install with: \`npm i tubular-fabric@${{ steps.version.outputs.value }}\` (the '${{ inputs.dist_tag }}' tag was used, so 'latest' is unchanged)." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-manual.yml` — a `workflow_dispatch` (manual, run-from-the-Actions-UI) workflow to publish `tubular-fabric` **from any branch**, on demand.

## Why

The existing automatic `npm Publish` workflow only fires on push to `master` and always bumps a **minor** on the master line. That makes it impossible to cut a **maintenance / back-port release** — e.g. shipping a bug fix on the `3.13.x` line for a downstream consumer that pins `3.13.0` — without adopting master's newer transitive dependencies (master already moved `tubular-common` 6 → 7).

This gives us a controlled, repeatable way to publish a fix on an older line, and is reusable for any future hotfix/back-port.

## How it works

- Runs only when triggered manually from **Actions → npm Publish (manual) → Run workflow**.
- Inputs:
  - **`branch`** — the branch whose code is built and published (checkout uses this input, so the target branch does **not** need to contain this file).
  - **`bump`** — `patch` / `minor` / `major` / `none` applied before publishing.
  - **`dist_tag`** — npm dist-tag to publish under (default `v3-lts`) so a back-port release does **not** move `latest` away from the master line.
- Reuses the existing `NPM_TOKEN` and `GPR_ACCESS_TOKEN` repo secrets and the same pnpm build + publish steps as the canonical workflow.
- After publishing, commits the version bump back to the target branch (only `package.json`), and writes a summary with the published version + dist-tag.

## Notes

- This workflow only needs to exist on the default branch to appear in the "Run workflow" UI; it publishes the selected branch's code regardless of whether that branch has the file.
- `pnpm` is pinned to `9` to match the repo's `lockfileVersion: 9.0` and stay compatible with the pinned Node `18.20.4`.
- No effect on the existing automatic publish flow.

## First intended use

Ship the date-"Between" filter fix (#663) as `tubular-fabric@3.13.1` from a `3.13.x` maintenance branch, under the `v3-lts` tag, so `core-webparts` can bump `3.13.0 → 3.13.1` as a drop-in without the `tubular-common` 6 → 7 jump.
